### PR TITLE
Add EnumMember type to MetaStuff.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ example/Makefile
 example/meta_example
 example/MetaExample/
 *.cmake
+**Build/

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(MetaStuffExample)
+
+# Bit hacky but whatever it works for examples.
+set(MetaStuffExample_SOURCES
+    JsonCast.cpp
+    JsonCast.h
+    JsonCast.inl
+    MovieInfo.h
+    Person.h
+    StringCast.cpp
+    StringCast.h
+    jsoncpp/jsoncpp.cpp)
+
+set(INCLUDE_DIRS
+    ${PROJECT_SOURCE_DIR}/jsoncpp/
+    ${PROJECT_SOURCE_DIR}/../include/)
+
+add_executable(MetaStuffExample main.cpp ${MetaStuffExample_SOURCES})
+
+target_include_directories(MetaStuffExample PRIVATE
+    ${INCLUDE_DIRS})
+
+set_target_properties(MetaStuffExample PROPERTIES DEBUG_POSTFIX _d)

--- a/example/JsonCast.inl
+++ b/example/JsonCast.inl
@@ -29,9 +29,17 @@ Value serialize_impl(const Class& obj)
     {
         auto& valueName = value[member.getName()];
         if (member.canGetConstRef()) {
+          if ( member.is_enum() ) {
+            valueName = serialize(member.as_enum().toString(member.get(obj)));
+          } else {
             valueName = serialize(member.get(obj));
+          }
         } else if (member.hasGetter()) {
+          if ( member.is_enum() ) {
+            valueName = serialize(member.as_enum().toString(member.getCopy(obj)));
+          } else {
             valueName = serialize(member.getCopy(obj)); // passing copy as const ref, it's okay
+          }
         } else {
             throw std::runtime_error("Error: can't deserialize member because it's write only");
         }

--- a/example/Person.h
+++ b/example/Person.h
@@ -8,6 +8,12 @@
 
 #include <iostream>
 
+enum class PersonType {
+  UNKNOWN = 0,
+  EMPLOYEE = 3,
+  ATTENDEE = 5
+};
+
 struct Person {
     // add this if you want to register private members:
     // template <>
@@ -44,6 +50,7 @@ struct Person {
     std::string name;
     float salary;
     std::unordered_map<std::string, std::vector<MovieInfo>> favouriteMovies;
+    PersonType type = PersonType::UNKNOWN;
 };
 
 #include <Meta.h>
@@ -58,7 +65,11 @@ inline auto registerMembers<Person>()
         member("age", &Person::getAge, &Person::setAge), // access through getter/setter only!
         member("name", &Person::getName, &Person::setName), // same, but ref getter/setter
         member("salary", &Person::salary),
-        member("favouriteMovies", &Person::favouriteMovies)
+        member("favouriteMovies", &Person::favouriteMovies),
+        enummember("type", &Person::type)  // Enum class works too!
+        .value("Employee", PersonType::EMPLOYEE)
+        .value("Unknown", PersonType::UNKNOWN)
+        .value("Attendee", PersonType::ATTENDEE)
     );
 }
 

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -22,7 +22,8 @@ int main()
     person.age = 25;
     person.salary = 3.50f;
     person.name = "Alex"; // I'm a person!
-    
+    person.type = PersonType::ATTENDEE; // I'm paying for all these movies!
+
     person.favouriteMovies["Nostalgia Critic"] = { MovieInfo{ "The Room", 8.5f } };
     person.favouriteMovies["John Tron"] = { MovieInfo{ "Goosebumps", 10.0f },
                                             MovieInfo{ "Talking Cat", 9.0f } };
@@ -70,6 +71,18 @@ int main()
     meta::setMemberValue<std::string>(person, "name", "Ron Burgundy");
     name = meta::getMemberValue<std::string>(person, "name");
     std::cout << "Changed person's name to " << name << '\n';
+
+
+    // getting setting enum member values
+    auto type = meta::getEnumMemberValueString<PersonType>(person, "type");
+    std::cout << "Got person's type: " << type << '\n';
+
+    // Set person's type to some real value
+    meta::setEnumMemberValueString<PersonType>(person, "type", "Employee");
+    type = meta::getEnumMemberValueString<PersonType>(person, "type");
+    std::cout << "Changed person's type: " << type << '\n';
+
+
 
     printSeparator();
 

--- a/include/Member.h
+++ b/include/Member.h
@@ -13,6 +13,10 @@ set them in the other place?)
 
 #pragma once
 
+#include <unordered_map>
+#include <string>
+#include <type_traits>
+
 
 namespace meta
 {
@@ -41,6 +45,9 @@ using nonconst_ref_getter_func_ptr_t = T& (Class::*)();
 // MemberType is Member<T, Class>
 template <typename MemberType>
 using get_member_type = typename std::decay_t<MemberType>::member_type;
+
+template <typename Class, typename T>
+class EnumMember;
 
 template <typename Class, typename T>
 class Member {
@@ -72,6 +79,15 @@ public:
     bool hasSetter() const { return refSetterPtr || valSetterPtr; }
     bool canGetConstRef() const { return hasMemberPtr || refGetterPtr; }
     bool canGetRef() const { return hasMemberPtr || nonConstRefGetterPtr; }
+    bool is_enum() const { return std::is_enum<T>::value; }
+    
+    // Downcast to EnumMemberType, should only use if is_enum is true.
+    using EnumMemberType = EnumMember<Class, T>;
+    const EnumMemberType as_enum() const {
+      assert(this->is_enum() && "to_enum_member used for non-enum type!");
+      const EnumMemberType& enum_member = static_cast<const EnumMemberType&>(*this);
+      return enum_member; 
+    }
 private:
     const char* name;
     member_ptr_t<Class, T> ptr;
@@ -87,6 +103,122 @@ private:
     nonconst_ref_getter_func_ptr_t<Class, T> nonConstRefGetterPtr;
 };
 
+
+template<typename T>
+struct EnumClassHash {
+  template<typename U = T,
+    typename = std::enable_if_t<std::is_enum<T>::value>>
+  std::size_t operator()(T const& val) const {
+    using underlying_type = typename std::underlying_type<T>::type;
+    const underlying_type u_val = static_cast<underlying_type>(val);
+    std::hash<underlying_type> hfn;
+    return hfn(u_val);
+  }
+
+  std::size_t operator()(T const& val) const {
+    assert("Something has gone horribly wrong for you to call this on a non-enum type");
+    return 0;
+  }
+};
+
+template <typename, typename>
+class EnumVoidMap {
+public:
+
+};
+
+
+template <typename Class, typename T>
+class EnumMember : public Member<Class, T> {
+public:
+    using Member<Class, T>::Member;
+
+    // Used for when Member is of type Enum
+    using to_str_map_type = std::unordered_map<T, std::string, EnumClassHash<T>>;
+    using from_str_map_type = std::unordered_map<std::string, T>;
+
+    // Enable assigning .value() for enum members
+    template <typename U = T>
+    typename std::enable_if<std::is_enum<U>::value, EnumMember&>::type
+    value(const char* name, T value) {
+      auto& to_str_map = this->to_str_map();
+      auto& from_str_map = this->from_str_map();
+      to_str_map[value] = name;
+      from_str_map[name] = value;
+      return *this;
+    }
+
+
+    template <typename U = T>
+    typename std::enable_if<std::is_enum<U>::value, std::string&>::type
+    toString(const T value) const {
+      auto& to_str_map = this->to_str_map();
+      return to_str_map[value];
+    }
+
+    template <typename U = T>
+    typename std::enable_if<std::is_enum<U>::value, U>::type
+    fromString(const std::string& name) const {
+      auto& from_str_map = this->from_str_map();
+      return from_str_map[name];
+    }
+
+    template <typename U = T>
+    typename std::enable_if<!std::is_enum<U>::value, std::string>::type
+    toString(const T value) const {
+      assert("Called EnumMember method on non-enum type class. Something went horribly wrong!");
+      (void)value;
+      return std::string("");;
+    }
+
+    template <typename U = T>
+    typename std::enable_if<!std::is_enum<U>::value, U>::type
+    fromString(const std::string& name) const {
+      assert("Called EnumMember method on non-enum type class. Something went horribly wrong!");
+      (void)name;
+      U v;
+      return v;
+    }
+private:
+  // Provide static maps for enums
+  template <typename U = T>
+  typename std::enable_if<!std::is_enum<U>::value, EnumVoidMap<U,U>>::type
+    to_str_map() const {
+    assert("Called EnumMember method on non-enum type class. Something went horribly wrong!");
+    return EnumVoidMap();
+  }
+
+  template <typename U = T>
+  typename std::enable_if<!std::is_enum<U>::value, EnumVoidMap<U, U>>::type
+    from_str_map() const {
+    assert("Called EnumMember method on non-enum type class. Something went horribly wrong!");
+    return EnumVoidMap();
+  }
+
+  // Enable assigning .value() for enum members
+  template <typename U = T>
+  typename std::enable_if<!std::is_enum<U>::value, EnumMember&>::type
+    value(const char* name, T value) {
+    assert("Called EnumMember method on non-enum type class. Something went horribly wrong!");
+    return *this;
+  }
+
+  // Provide static maps for enums
+  template <typename U = T>
+  typename std::enable_if<std::is_enum<U>::value, to_str_map_type&>::type
+    to_str_map() const {
+    static to_str_map_type map;
+    return map;
+  }
+
+  template <typename U = T>
+  typename std::enable_if<std::is_enum<U>::value, from_str_map_type&>::type
+    from_str_map() const {
+    static from_str_map_type map;
+    return map;
+  }
+};
+
 // useful function similar to make_pair which is used so you don't have to write this:
 // Member<SomeClass, int>("someName", &SomeClass::someInt); and can just to this:
 // member("someName", &SomeClass::someInt);
@@ -99,6 +231,21 @@ Member<Class, T> member(const char* name, ref_getter_func_ptr_t<Class, T> getter
 
 template <typename Class, typename T>
 Member<Class, T> member(const char* name, val_getter_func_ptr_t<Class, T> getterPtr, val_setter_func_ptr_t<Class, T> setterPtr);
+
+// Useful for assigning enums
+// member("someName", &SomeClass::someEnum)
+//  .value("VAL1", SomeEnum::Val1);
+template <typename Class, typename T,
+   typename = std::enable_if_t<std::is_enum<T>::value>>
+  EnumMember<Class, T> enummember(const char* name, T Class::* ptr);
+
+template <typename Class, typename T,
+  typename = std::enable_if_t<std::is_enum<T>::value>>
+EnumMember<Class, T> enummember(const char* name, ref_getter_func_ptr_t<Class, T> getterPtr, ref_setter_func_ptr_t<Class, T> setterPtr);
+
+template <typename Class, typename T,
+  typename = std::enable_if_t<std::is_enum<T>::value>>
+EnumMember<Class, T> enummember(const char* name, val_getter_func_ptr_t<Class, T> getterPtr, val_setter_func_ptr_t<Class, T> setterPtr);
 
 } // end of namespace meta
 

--- a/include/Member.inl
+++ b/include/Member.inl
@@ -16,7 +16,7 @@ Member<Class, T>::Member(const char* name, member_ptr_t<Class, T> ptr) :
 { }
 
 template <typename Class, typename T>
-Member<Class, T>::Member(const char* name, ref_getter_func_ptr_t<Class, T> getterPtr, ref_setter_func_ptr_t<Class, T> setterPtr) : 
+Member<Class, T>::Member(const char* name, ref_getter_func_ptr_t<Class, T> getterPtr, ref_setter_func_ptr_t<Class, T> setterPtr) :
     name(name),
     ptr(nullptr),
     hasMemberPtr(false),
@@ -121,6 +121,27 @@ template <typename Class, typename T>
 Member<Class, T> member(const char* name, val_getter_func_ptr_t<Class, T> getterPtr, val_setter_func_ptr_t<Class, T> setterPtr)
 {
     return Member<Class, T>(name, getterPtr, setterPtr);
+}
+
+template <typename Class, typename T,
+    typename>
+EnumMember<Class, T> enummember(const char* name, T Class::* ptr)
+{
+    return EnumMember<Class, T>(name, ptr);
+}
+
+template <typename Class, typename T,
+    typename>
+EnumMember<Class, T> enummember(const char* name, ref_getter_func_ptr_t<Class, T> getterPtr, ref_setter_func_ptr_t<Class, T> setterPtr)
+{
+    return EnumMember<Class, T>(name, getterPtr, setterPtr);
+}
+
+template <typename Class, typename T,
+    typename>
+EnumMember<Class, T> enummember(const char* name, val_getter_func_ptr_t<Class, T> getterPtr, val_setter_func_ptr_t<Class, T> setterPtr)
+{
+    return EnumMember<Class, T>(name, getterPtr, setterPtr);
 }
 
 } // end of namespace meta

--- a/include/Meta.h
+++ b/include/Meta.h
@@ -113,6 +113,17 @@ template <typename T, typename Class, typename V,
     typename = std::enable_if_t<std::is_constructible<T, V>::value>>
 void setMemberValue(Class& obj, const std::string& name, V&& value);
 
+// Get value of the enum member named 'name' as string
+template <typename T, typename Class,
+    typename = std::enable_if_t<std::is_enum<T>::value>>
+std::string getEnumMemberValueString(Class& obj, const std::string& name);
+
+// Sets value of the enum member named 'name' using a string
+template <typename T, typename Class,
+    typename = std::enable_if_t<std::is_enum<T>::value>>
+void setEnumMemberValueString(Class& obj, const std::string& name, const std::string& value);
+
+
 }
 
 #include "Meta.inl"

--- a/include/Meta.inl
+++ b/include/Meta.inl
@@ -115,4 +115,30 @@ void setMemberValue(Class& obj, const std::string& name, V&& value)
     );
 }
 
+// Get value of the enum member named 'name' as string
+template <typename T, typename Class,
+    typename>
+std::string getEnumMemberValueString(Class& obj, const std::string& name) {
+    std::string value;
+    doForMember<Class, T>(name,
+        [&value, &obj](const auto& member)
+        {
+            value = member.toString(member.get(obj));
+        }
+    );
+    return value;
+}
+
+// Sets value of the enum member named 'name' using a string
+template <typename T, typename Class,
+    typename>
+void setEnumMemberValueString(Class& obj, const std::string& name, const std::string& value){
+    doForMember<Class, T>(name,
+        [&obj, &value](const auto& member)
+        {
+            member.set(obj, member.fromString(value));
+        }
+    );
+}
+
 } // end of namespace meta


### PR DESCRIPTION
Adds CMakeLists.txt for example for easier compilation.

Documentation is being added as we speak, putting code up for review so any changes needed to be made will be made.

EnumMember is implements a toString and fromString to convert Enum types from and to strings instead of by numeric number.

Implementation is rough, as the map is generated per-clas,, any ideas on how to move it to per-enum?Unless theres a use case for to map the same enum as different string values....