### PR TITLE
Fix typo in JSON example documentation

### DIFF
--- a/example/JsonCast.inl
+++ b/example/JsonCast.inl
@@ -15,7 +15,7 @@ void from_json(const json& j, T& obj)
 namespace meta
 {
 
-/////////////////// DESERIALIZATION
+/////////////////// SERIALIZATION
 
 template <typename Class,
     typename>


### PR DESCRIPTION
There are two sections called `DESERIALIZATION`, but the first handles the serialization. It's just a minor typo. Still can lead to confusion if you await deserialization and see `serialize` first.

\*edit\*: I'm sorry about the newline at end of file change, that was done by the GitHub editor.