### PR TITLE
Return default constructed value in example

### DIFF
--- a/example/StringCast.h
+++ b/example/StringCast.h
@@ -39,5 +39,5 @@ std::string castToString(const T& /* value */)
 template <typename T>
 T fromString(const std::string& /* value */)
 {
-    return T;
+    return T();
 }


### PR DESCRIPTION
`T` is a type in that context, not value. We have to default construct one.

In case VS does not show that error here are the error messages in clang and gcc:

``` bash
$ clang++ -std=c++14 -c MetaStuff/example/StringCast.h -I ./MetaStuff/example/nlohmann_json/ -I ./MetaStuff/include/
clang: warning: treating 'c-header' input as 'c++-header' when in C++ mode, this behavior is deprecated
MetaStuff/example/StringCast.h:2:9: warning: #pragma once in main file [-Wpragma-once-outside-header]
#pragma once
        ^
MetaStuff/example/StringCast.h:42:12: error: 'T' does not refer to a value
    return T;
           ^
MetaStuff/example/StringCast.h:39:20: note: declared here
template <typename T>
                   ^
```
``` bash 
$ g++ -std=c++14 -c MetaStuff/example/StringCast.h -I ./MetaStuff/example/nlohmann_json/ -I ./MetaStuff/include/
MetaStuff/example/StringCast.h:2:9: warning: #pragma once in main file
 #pragma once
         ^
MetaStuff/example/StringCast.h: In function ‘T fromString(const string&)’:
MetaStuff/example/StringCast.h:42:13: error: expected primary-expression before ‘;’ token
     return T;
             ^
```