### PR TITLE
Add members_cat

### DIFF
--- a/include/Meta.h
+++ b/include/Meta.h
@@ -56,6 +56,9 @@ namespace meta
 template <typename... Args>
 auto members(Args&&... args);
 
+template <typename Tuple, typename... Args>
+auto members_cat(Tuple&& tuple, Args&&... args);
+    
 // function used for registration of classes by user
 template <typename Class>
 inline auto registerMembers();

--- a/include/Meta.inl
+++ b/include/Meta.inl
@@ -17,6 +17,13 @@ auto members(Args&&... args)
     return std::make_tuple(std::forward<Args>(args)...);
 }
 
+template <typename Tuple, typename... Args>
+auto members_cat(Tuple&& tuple, Args&&... args)
+{
+    auto newMembers = members(std::forward<Args>(args)...);
+    return std::tuple_cat(tuple, newMembers);
+}
+    
 template <typename Class>
 inline auto registerMembers()
 {


### PR DESCRIPTION
Hides the std::tuple details away if the user needs to concat 2 lists of members together.