### PR TITLE
Add getMemberCount() function

### DIFF
--- a/example/JsonCast.inl
+++ b/example/JsonCast.inl
@@ -95,9 +95,9 @@ void deserialize(Class& obj, const json& object)
                 if (!objName.is_null()) {
                     using MemberT = meta::get_member_type<decltype(member)>;
                     if (member.hasSetter()) {
-                        member.set(obj, objName.get<MemberT>());
+                        member.set(obj, objName.template get<MemberT>());
                     } else if (member.canGetRef()) {
-                        member.getRef(obj) = objName.get<MemberT>();
+                        member.getRef(obj) = objName.template get<MemberT>();
                     } else {
                         throw std::runtime_error("Error: can't deserialize member because it's read only");
                     }

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -48,13 +48,16 @@ int main()
     // checking if classes are registered
     if (meta::isRegistered<Person>()) {
         std::cout << "Person class is registered\n";
+		std::cout << "It has " << meta::getMemberCount<Person>() << " members registered.\n";
     }
 
     // meta::isRegistered is constexpr, so can be used in enable_if and static_assert!
     static_assert(meta::isRegistered<Person>(), "Person class is not registered!");
+	static_assert(meta::getMemberCount<Person>() == 4, "Person does not have 4 members registered?");
 
     if (!meta::isRegistered<Unregistered>()) {
         std::cout << "Unregistered class is unregistered\n";
+		std::cout << "It has " << meta::getMemberCount<Unregistered>() << " members registered.\n";
     }
 
     // checking if class has a member

--- a/include/Meta.h
+++ b/include/Meta.h
@@ -68,6 +68,10 @@ constexpr auto registerName();
 template <typename Class>
 constexpr auto getName();
 
+// returns the number of registered members of the class
+template <typename Class>
+constexpr std::size_t getMemberCount();
+
 // returns std::tuple of Members
 template <typename Class>
 const auto& getMembers();

--- a/include/Meta.inl
+++ b/include/Meta.inl
@@ -36,6 +36,12 @@ constexpr auto getName()
 }
 
 template <typename Class>
+constexpr std::size_t getMemberCount()
+{
+	return std::tuple_size<decltype(registerMembers<Class>())>::value;
+}
+
+template <typename Class>
 const auto& getMembers()
 {
     return detail::MetaHolder<Class, decltype(registerMembers<Class>())>::members;


### PR DESCRIPTION
This pull request adds the function
```c++
// returns the number of registered members of the class
template <typename Class>
constexpr std::size_t getMemberCount();
```
to the `meta `namespace and adds respective calls to the example code (See https://github.com/eliasdaler/MetaStuff/issues/15).
Furthermore, it fixes a bug in the `JsonCast.inl` file (in the definition of `deserialize`) where the `template` keyword was missing when calling the templated json `get` member function.